### PR TITLE
Ensure to break inside switches

### DIFF
--- a/api/index.js
+++ b/api/index.js
@@ -62,12 +62,15 @@ router
         switch (action) {
           case 'create': {
             dbQuery = bookService.createBook(book);
+            break;
           }
           case 'update': {
             dbQuery = bookService.updateBook(id, rating);
+            break;
           }
           case 'delete': {
             dbQuery = bookService.deleteBook(id);
+            break;
           }
         }
 


### PR DESCRIPTION
This should fix #6.

The issue was that there was no break in the switch so everything would run create/update/delete in that order. With the breaks, it will now only run the required method.